### PR TITLE
Fix/use video cta url

### DIFF
--- a/models/stitch/base/fb_ad_creatives.sql
+++ b/models/stitch/base/fb_ad_creatives.sql
@@ -4,9 +4,10 @@ with base as (
     id,
     url_tags,
     coalesce(
-      object_story_spec__link_data__call_to_action__value__link,
-      object_story_spec__link_data__link,
-      link_url
+      nullif(object_story_spec__link_data__call_to_action__value__link, ''),
+      nullif(object_story_spec__video_data__call_to_action__value__link, '')
+      nullif(object_story_spec__link_data__link, ''),
+      nullif(link_url, ''),
     ) as url
   from
     {{ var('ad_creatives_table') }}

--- a/models/stitch/base/fb_ad_creatives.sql
+++ b/models/stitch/base/fb_ad_creatives.sql
@@ -5,9 +5,9 @@ with base as (
     url_tags,
     coalesce(
       nullif(object_story_spec__link_data__call_to_action__value__link, ''),
-      nullif(object_story_spec__video_data__call_to_action__value__link, '')
+      nullif(object_story_spec__video_data__call_to_action__value__link, ''),
       nullif(object_story_spec__link_data__link, ''),
-      nullif(link_url, ''),
+      nullif(link_url, '')
     ) as url
   from
     {{ var('ad_creatives_table') }}


### PR DESCRIPTION
We previously weren't setting the url correctly for fb video ads