### PR TITLE
add url_host and url_path back to model for snowflake version

### DIFF
--- a/macros/stitch/base/stitch_fb_ad_creatives.sql
+++ b/macros/stitch/base/stitch_fb_ad_creatives.sql
@@ -76,6 +76,9 @@ parsed as (
     
         creative_id,
         url,
+        {{ dbt_utils.get_url_host('url') }} as url_host,
+        '/' || {{dbt_utils.get_url_path('url') }} as url_path,
+        
         {{ facebook_ads.get_url_parameter() }}
         
     from base 


### PR DESCRIPTION
* re-added `url_host` and `url_path` back to `fb_ad_creatives` model