### PR TITLE
call dispatch() in stitch_fb_ads_adsets, set packages arg

### DIFF
--- a/macros/stitch/base/stitch_fb_ads_adsets.sql
+++ b/macros/stitch/base/stitch_fb_ads_adsets.sql
@@ -1,6 +1,6 @@
 {% macro stitch_fb_ads_adsets() %}
 
-    {{ adapter.dispatch('stitch_fb_ads_adsets') }}
+    {{ adapter.dispatch('stitch_fb_ads_adsets',packages=facebook_ads._get_facebook_ads_namespaces())() }}
 
 {% endmacro %}
 


### PR DESCRIPTION
## Description & motivation
The returned macro from `adapter.dispatch('stitch_fb_ads_adsets')` wasn't being called, so in the compiled code we received this instead:

```
  create or replace  view analytics.my_schema.fb_ads_adsets  as (
  
    <dbt.clients.jinja.MacroGenerator object at 0x1064ea0a0>

  );
```

resulting in this error:

```
Database Error in model fb_ads_adsets (models/router/stitch/fb_ads_adsets.sql)
  001003 (42000): SQL compilation error:
  syntax error line 6 at position 4 unexpected '<'.
  compiled SQL at target/run/facebook_ads/models/router/stitch/fb_ads_adsets.sql
```

I also added a `packages` argument to the macro call to be in line with the others in the package. 

## Checklist
- [x] I have verified that these changes work locally
~I have updated the README.md (if applicable)~
~I have added tests & descriptions to my models (and macros if applicable~